### PR TITLE
Add support for bearer token auth

### DIFF
--- a/config.js
+++ b/config.js
@@ -3,5 +3,8 @@ config.concourse_url = "https://ci.concourse.ci"; //Replace with your concourse 
 config.api_subdirectory = "/api/v1";
 config.concourse_username = "YOUR_CONCOURSE_USERNAME_HERE";
 config.concourse_password = "YOUR_CONCOURSE_PASSWORD_HERE";
+config.concourse_team="YOUR_CONCOURSE_TEAM_HERE"
+config.use_bearer_token=false
+
 
 module.exports = config;

--- a/views/overview.pug
+++ b/views/overview.pug
@@ -9,7 +9,7 @@ html
 			center
 				each pipeline in pipelines
 					a(href=config.concourse_url + pipeline.url)
-						.pipeline(class=pipeline.status)=pipeline.name
+						div(class='pipeline ' + pipeline.status)=pipeline.name
 		.footer
 			|Last Updated: 
 			script(type='text/javascript').


### PR DESCRIPTION
Adding support to use bearer token as an auth method. Will only use this
method if user enable the config.use_bearer_token configuration.

Added async as we need to make sure the bearer token is available for
the pipelines and pipeline status request. Might be better to pass that
token in instead but will investigate that next time.